### PR TITLE
Fix: Data is mixed-up when schemas share table names

### DIFF
--- a/sql/column.sql
+++ b/sql/column.sql
@@ -1,59 +1,61 @@
 -- Should return:
 -- schemaName, tableName, name, default, allowNull, type, special, length, precision, scale, arrayType, arrayDimension, position, description
 SELECT
-  CONCAT(table_catalog, '.', table_schema, '.', table_name)          AS "parent",
-  table_catalog                                                      AS "db",
-  table_schema                                                       AS "schema",
+-- 	c.*,
+-- 	'|' as "|",
+  CONCAT(cols.table_catalog, '.', cols.table_schema, '.', cols.table_name)          AS "parent",
+  cols.table_schema                                                       AS "schema",
+  cols.table_catalog                                                      AS "db",
   pg_catalog.obj_description(c.relnamespace, 'pg_namespace')         AS "schemaComment",
   CASE c.relkind
       WHEN 'r' THEN 'table'
       WHEN 'v' THEN 'view'
   END                                                                AS "kind",
-  table_name                                                         AS "table",
+  cols.table_name                                                         AS "table",
   pg_catalog.obj_description(c.oid, 'pg_class')                      AS "tableDescription",
-  column_name                                                        AS "name",
-  CONCAT(table_schema, '.', table_name, '.', column_name)            AS "fullName",
-  CONCAT(table_catalog, '.', table_schema, '.', table_name, '.', column_name) AS "fullCatalogName",
-  column_default                                                     AS "defaultWithTypeCast",
-  CASE WHEN column_default ILIKE 'nextval%' THEN TRUE ELSE FALSE END AS "isAutoIncrement",
-  CAST(is_nullable AS BOOLEAN)                                       AS "allowNull",
-  CASE WHEN udt_name = 'hstore' THEN udt_name
-  ELSE LOWER(data_type) END                                          AS "type",
+  cols.column_name                                                        AS "name",
+  CONCAT(cols.table_schema, '.', cols.table_name, '.', cols.column_name)            AS "fullName",
+  CONCAT(cols.table_catalog, '.', cols.table_schema, '.', cols.table_name, '.', cols.column_name) AS "fullCatalogName",
+  cols.column_default                                                     AS "defaultWithTypeCast",
+  CASE WHEN cols.column_default ILIKE 'nextval%' THEN TRUE ELSE FALSE END AS "isAutoIncrement",
+  CAST(cols.is_nullable AS BOOLEAN)                                       AS "allowNull",
+  CASE WHEN cols.udt_name = 'hstore' THEN cols.udt_name
+  ELSE LOWER(cols.data_type) END                                          AS "type",
   t.typcategory                                                      AS "typeCategory", -- See http://www.postgresql.org/docs/current/static/catalog-pg-type.html
   CASE WHEN t.typcategory = 'E' THEN
       (SELECT Array_agg(e.enumlabel)
        FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid = e.enumtypid
        WHERE t.typname = udt_name)
   ELSE NULL END                                                      AS "enumValues",
-  CASE WHEN LOWER(data_type) = 'array' THEN information_schema._pg_char_max_length(arraytype.oid, a.atttypmod)
-  ELSE character_maximum_length END                                  AS "length",
-  CASE WHEN LOWER(data_type) = 'array' THEN COALESCE(
+  CASE WHEN LOWER(cols.data_type) = 'array' THEN information_schema._pg_char_max_length(arraytype.oid, a.atttypmod)
+  ELSE cols.character_maximum_length END                                  AS "length",
+  CASE WHEN LOWER(cols.data_type) = 'array' THEN COALESCE(
       information_schema._pg_datetime_precision(arraytype.oid, a.atttypmod),
       information_schema._pg_numeric_precision(arraytype.oid, a.atttypmod))
-  WHEN datetime_precision IS NULL THEN numeric_precision
-  ELSE datetime_precision END                                        AS "precision",
-  CASE WHEN LOWER(data_type) = 'array' THEN information_schema._pg_numeric_scale(arraytype.oid, a.atttypmod)
-  ELSE numeric_scale END                                             AS "scale",
-  CASE WHEN LEFT(udt_name, 1) = '_' THEN LEFT(format_type(a.atttypid, NULL), -2)
+  WHEN cols.datetime_precision IS NULL THEN numeric_precision
+  ELSE cols.datetime_precision END                                        AS "precision",
+  CASE WHEN LOWER(cols.data_type) = 'array' THEN information_schema._pg_numeric_scale(arraytype.oid, a.atttypmod)
+  ELSE cols.numeric_scale END                                             AS "scale",
+  CASE WHEN LEFT(cols.udt_name, 1) = '_' THEN LEFT(format_type(a.atttypid, NULL), -2)
   ELSE NULL END                                                      AS "arrayType",
   a.attndims                                                         AS "arrayDimension",
-  domain_catalog                                                     AS "domainCatalog",
-  domain_schema                                                      AS "domainSchema",
-  domain_name                                                        AS "domainName",
+  cols.domain_catalog                                                     AS "domainCatalog",
+  cols.domain_schema                                                      AS "domainSchema",
+  cols.domain_name                                                        AS "domainName",
   CASE WHEN t.typcategory IN ('E', 'C') THEN format_type(a.atttypid, NULL)
   ELSE NULL END                                                      AS "userDefinedType",
-  udt_name                                                           AS "udtName",      -- User Defined Types such as composite, enumerated etc.
-  ordinal_position                                                   AS "position",
-  pg_catalog.col_description(c.oid, columns.ordinal_position :: INT) AS "description"
-FROM information_schema.columns
-  INNER JOIN pg_catalog.pg_attribute a ON a.attname = column_name
-  INNER JOIN pg_catalog.pg_class c ON c.oid = a.attrelid AND c.relname = table_name
+  cols.udt_name                                                           AS "udtName",      -- User Defined Types such as composite, enumerated etc.
+  cols.ordinal_position                                                   AS "position",
+  pg_catalog.col_description(c.oid, cols.ordinal_position :: INT) AS "description"
+FROM information_schema.columns cols
+  INNER JOIN pg_catalog.pg_class c ON c.oid = (SELECT ('"' || cols.table_schema || '"."' || cols.table_name || '"')::regclass::oid) AND c.relname = cols.table_name
+  INNER JOIN pg_catalog.pg_attribute a ON c.oid = a.attrelid and a.attname = cols.column_name
   --LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace AND pg_catalog.pg_table_is_visible(c.oid)
-  LEFT JOIN pg_catalog.pg_type arraytype ON arraytype.typname = RIGHT(udt_name, -1)
+  LEFT JOIN pg_catalog.pg_type arraytype ON arraytype.typname = RIGHT(cols.udt_name, -1)
   INNER JOIN pg_type t ON a.atttypid = t.oid
 WHERE table_schema = ANY($1)
 --WHERE table_schema = 'public'
-ORDER BY table_schema, table_name, ordinal_position
+ORDER BY cols.table_schema, cols.table_name, cols.ordinal_position
 
 
 -- NOTE: I tried to avoid joins by using information_schema.columns views's content as CTE after adding below selections.


### PR DESCRIPTION
I have a database where where one schema has views that are named exactly the same as tables in another schema. I was getting inconsistent results every time I call `pgGenerate`, particularly with `DescriptionData`.

Although I made many changes to `column.sql`, the only change necessary to fix this is related to how `pg_catalog.pg_class` was joined in.

I'm not sure if my change affects which versions of Postgres that this tool is compatible with. I used this answer to help me change the query https://stackoverflow.com/a/22547588/787757

This change fixed my issues and seems to be working for me but I haven't run your test suite.