### PR TITLE
feat: add support for indexes on materialized views

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -249,17 +249,17 @@ function addColumns(db: Db, rows: ColumnQueryResult[]): void {
  */
 function addIndexes(db: Db, rows: IndexQueryResult[]): void {
   rows.forEach((row) => {
-    const table = db.tables.get(row.tableOid, { key: "oid" }) as Table;
-    const index = new Index({ ...row, table });
+    const parent = db.entities.get(row.tableOid, { key: "oid" }) as Table | MaterializedView;
+    const index = new Index({ ...row, parent });
     const indexExpressions = [...row.indexExpressions]; // Non column reference index expressions.
 
     row.columnPositions.forEach((position) => {
       // If position is 0, then it's an index attribute that is not simple column references. It is an expression which is stored in indexExpressions.
-      const columnOrExpression = position > 0 ? table.columns[position - 1] : (indexExpressions.shift() as string);
+      const columnOrExpression = position > 0 ? parent.columns[position - 1] : (indexExpressions.shift() as string);
       index.columnsAndExpressions.push(columnOrExpression);
     });
 
-    table.indexes.push(index);
+    parent.indexes.push(index);
   });
 }
 

--- a/src/pg-structure/constraint/foreign-key.ts
+++ b/src/pg-structure/constraint/foreign-key.ts
@@ -64,7 +64,9 @@ export default class ForeignKey extends Constraint {
    * This is [[Table]] instance this {@link ForeignKey foreign key} refers to.
    */
   public get referencedTable(): Table {
-    return this.index.table;
+    // it's not possible to have an foreign key on a materialized view, so
+    // `index.table` will always be defined
+    return this.index.table as Table;
   }
 
   /**

--- a/src/pg-structure/entity/materialized-view.ts
+++ b/src/pg-structure/entity/materialized-view.ts
@@ -1,6 +1,13 @@
+import IndexableArray from "indexable-array";
 import Entity from "../base/entity";
+import Index from "..";
 
 /**
  * Class which represent a {@link MaterializedView materialized view}. Provides attributes and methods for details of the {@link MaterializedView materialized view}.
  */
-export default class MaterializedView extends Entity {}
+export default class MaterializedView extends Entity {
+  /**
+   * All {@link Index indexes} in the materialized view as an [[IndexableArray]], ordered by name.
+   */
+  public readonly indexes: IndexableArray<Index, "name", never, true> = IndexableArray.throwingFrom([], "name");
+}

--- a/src/pg-structure/index.ts
+++ b/src/pg-structure/index.ts
@@ -4,11 +4,13 @@ import Schema from "./schema";
 import Table from "./entity/table";
 import Column from "./column";
 import DbObject, { DbObjectConstructorArgs } from "./base/db-object";
+import MaterializedView from "./entity/materialized-view";
+import { Entity } from "..";
 
 /** @ignore */
 interface IndexConstructorArgs extends DbObjectConstructorArgs {
   oid: number;
-  table: Table;
+  parent: Entity;
   name: string;
   isUnique: boolean;
   isPrimaryKey: boolean;
@@ -27,7 +29,7 @@ export default class Index extends DbObject {
     this.isUnique = args.isUnique;
     this.isPrimaryKey = args.isPrimaryKey;
     this.isExclusion = args.isExclusion;
-    this.table = args.table;
+    this.parent = args.parent;
     this.partialIndexExpression = args.partialIndexExpression || undefined;
   }
 
@@ -35,7 +37,7 @@ export default class Index extends DbObject {
   public readonly oid: number;
 
   public get fullName(): string {
-    return `${this.schema.name}.${this.table.name}.${this.name}`;
+    return `${this.schema.name}.${this.parent.name}.${this.name}`;
   }
 
   /**
@@ -67,13 +69,24 @@ export default class Index extends DbObject {
   /**
    * {@link Table} which this {@link Index index} belongs to.
    */
-  public readonly table: Table;
+  public get table(): Table | undefined {
+    return this.parent instanceof Table ? this.parent : undefined;
+  }
+
+  /**
+   * {@link MaterializedView} which this {@link Index index} belongs to.
+   */
+  public get materializedView(): MaterializedView | undefined {
+    return this.parent instanceof MaterializedView ? this.parent : undefined;
+  }
+
+  public readonly parent: Entity;
 
   /**
    * {@link Schema} this {@link Index index} belongs to.
    */
   public get schema(): Schema {
-    return this.table.schema;
+    return this.parent.schema;
   }
 
   /**

--- a/test/entity/materialized-view.test.ts
+++ b/test/entity/materialized-view.test.ts
@@ -13,4 +13,8 @@ describe("MaterializedView", () => {
   it("should be a MaterializedView.", () => {
     expect(mView).toBeInstanceOf(MaterializedView);
   });
+
+  it("should have indexes.", () => {
+    expect(mView.indexes.map((i) => i.name)).toEqual(["mv_contact_other_schema_cart_cart_id_idx"]);
+  });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,69 +1,91 @@
 import IndexableArray from "indexable-array";
-import { Db, Index, Table } from "../src/index";
+import { Db, Index, Table, MaterializedView } from "../src/index";
 import getDb from "./test-helper/get-db";
 
 let db: Db;
 let table: Table;
-let indexes: IndexableArray<Index, "name", never, true>;
+let mView: MaterializedView;
+let mViewIndexes: IndexableArray<Index, "name", never, true>;
+let tableIndexes: IndexableArray<Index, "name", never, true>;
 
 beforeAll(async () => {
   db = await getDb();
   table = db.get("public.account") as Table;
-  indexes = table.indexes;
+  tableIndexes = table.indexes;
+  mView = db.get("public.mv_contact_other_schema_cart") as MaterializedView;
+  mViewIndexes = mView.indexes;
 });
 
 describe("Index", () => {
+  describe("on a table", () => {
+    it("should have table", () => {
+      expect(tableIndexes.get("ix_expression").table?.name).toBe("account");
+    });
+    it("should not have a materialized view", () => {
+      expect(tableIndexes.get("ix_expression").materializedView).toBeUndefined();
+    });
+  });
+  describe("on a materialized view", () => {
+    it("should have materialized view", () => {
+      expect(mViewIndexes.get("mv_contact_other_schema_cart_cart_id_idx").materializedView?.name).toBe("mv_contact_other_schema_cart");
+    });
+    it("should not have a table", () => {
+      expect(mViewIndexes.get("mv_contact_other_schema_cart_cart_id_idx").table).toBeUndefined();
+    });
+  });
   it("should have name.", () => {
-    expect(indexes.get("ix_expression").name).toBe("ix_expression");
+    expect(tableIndexes.get("ix_expression").name).toBe("ix_expression");
   });
 
   it("should have full name.", () => {
-    expect(indexes.get("ix_expression").fullName).toBe("public.account.ix_expression");
+    expect(tableIndexes.get("ix_expression").fullName).toBe("public.account.ix_expression");
   });
 
   it("should have oid.", () => {
-    expect(indexes.get("ix_expression").oid).toBeDefined();
+    expect(tableIndexes.get("ix_expression").oid).toBeDefined();
   });
 
-  it("should have table.", () => {
-    expect(indexes.get("ix_expression").table.name).toBe("account");
+  it("should have parent.", () => {
+    expect(tableIndexes.get("ix_expression").parent.name).toBe("account");
   });
 
   it("should have schema.", () => {
-    expect(indexes.get("ix_expression").schema.name).toBe("public");
+    expect(tableIndexes.get("ix_expression").schema.name).toBe("public");
   });
 
   it("should have expression.", () => {
-    expect(indexes.get("ix_expression").columnsAndExpressions[0]).toBe("lower((name)::text)");
+    expect(tableIndexes.get("ix_expression").columnsAndExpressions[0]).toBe("lower((name)::text)");
   });
 
   it("should have partial attribute.", () => {
-    expect(indexes.get("ix_partial_unique").isPartial).toBe(true);
+    expect(tableIndexes.get("ix_partial_unique").isPartial).toBe(true);
   });
 
   it("should have unique attribute.", () => {
-    expect(indexes.get("ix_partial_unique").isUnique).toBe(true);
+    expect(tableIndexes.get("ix_partial_unique").isUnique).toBe(true);
   });
 
   it("should have isExclusion attribute.", () => {
-    expect(indexes.get("ix_exclude").isExclusion).toBe(true);
+    expect(tableIndexes.get("ix_exclude").isExclusion).toBe(true);
   });
 
   it("should have isPrimaryKey attribute.", () => {
-    expect(indexes.get("KeyEntity11").isPrimaryKey).toBe(true);
+    expect(tableIndexes.get("KeyEntity11").isPrimaryKey).toBe(true);
   });
 
   it("should have partialIndexExpression attribute.", () => {
-    expect(indexes.get("ix_partial_unique").partialIndexExpression).toBe("(id > 99)");
+    expect(tableIndexes.get("ix_partial_unique").partialIndexExpression).toBe("(id > 99)");
   });
 
   it("should have columns.", () => {
-    expect(indexes.get("ix_columns").columns.map(c => c.name)).toEqual(["id", "name"]);
-    expect(indexes.get("ix_column_and_expression").columns.map(c => c.name)).toEqual(["id"]);
+    expect(tableIndexes.get("ix_columns").columns.map((c) => c.name)).toEqual(["id", "name"]);
+    expect(tableIndexes.get("ix_column_and_expression").columns.map((c) => c.name)).toEqual(["id"]);
   });
 
   it("should have columns and expressions.", () => {
     const expected = ["id", "lower((name)::text)"];
-    expect(indexes.get("ix_column_and_expression").columnsAndExpressions.map(c => (typeof c === "string" ? c : c.name))).toEqual(expected);
+    expect(tableIndexes.get("ix_column_and_expression").columnsAndExpressions.map((c) => (typeof c === "string" ? c : c.name))).toEqual(
+      expected
+    );
   });
 });

--- a/test/test-helper/ddl/main.sql
+++ b/test/test-helper/ddl/main.sql
@@ -388,6 +388,10 @@ FROM
   other_schema.cart
   INNER JOIN public.contact ON public.contact.id = other_schema.cart.contact_id;
 
+-- Create index for mv_contact_other_schema_cart
+
+CREATE INDEX "mv_contact_other_schema_cart_cart_id_idx" ON "mv_contact_other_schema_cart" ("cart_id");
+
 -- Create foreign keys (relationships) section -------------------------------------------------
 ALTER TABLE "public"."cart_line_item"
   ADD CONSTRAINT "cart_line_item_first_cart" FOREIGN KEY ("cart_id") REFERENCES "public"."cart" ("id") ON DELETE RESTRICT ON


### PR DESCRIPTION
Currently pg-structure throws an error if it encounters an index that is on a materialized view. This PR adds support for these.

Breaking changes: 
- `index.table` is now optional

Let me know if any additional changes would be helpful