### PR TITLE
Fix: associate indexes with the correct columns 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -305,7 +305,7 @@ function addIndexes(db: Db, rows: IndexQueryResult[]): void {
 
     row.columnPositions.forEach((position) => {
       // If position is 0, then it's an index attribute that is not simple column references. It is an expression which is stored in indexExpressions.
-      const columnOrExpression = position > 0 ? parent.columns[position - 1] : (indexExpressions.shift() as string);
+      const columnOrExpression = position > 0 ? parent.columns.find((c) => c.attributeNumber === position)! : (indexExpressions.shift() as string);
       index.columnsAndExpressions.push(columnOrExpression);
     });
 

--- a/test/test-helper/ddl/main.sql
+++ b/test/test-helper/ddl/main.sql
@@ -312,6 +312,7 @@ ALTER TABLE "public"."student" ADD CONSTRAINT "Key9" PRIMARY KEY ("first_name","
 CREATE TABLE "account"
 (
   "id" Serial NOT NULL,
+  "temp" integer, -- create a temporary column to drop later so that column.attributeNumber is no longer sequential
   "created_at" Timestamp(0) DEFAULT now() NOT NULL,
   "updated_at" Timestamp(0) DEFAULT now() NOT NULL,
   "name" Character varying(20) DEFAULT 'no_name' NOT NULL,
@@ -342,6 +343,9 @@ ALTER TABLE "account" ADD CONSTRAINT "KeyEntity11" PRIMARY KEY ("id")
 ;
 
 ALTER TABLE "account" ADD CONSTRAINT "account_unique_constraint" UNIQUE ("name","created_at")
+;
+
+ALTER TABLE "account" DROP COLUMN "temp"
 ;
 
 CREATE TRIGGER "account_updated_at"


### PR DESCRIPTION
Currently `addIndexes` is assuming that `table.columns[x-1].attributeNumber === x`, but this is not always the case.  For example, if you have 5 columns on a table and drop the second one, then the `table.columns.map((c) => c.attributeNumber)` would be `[1, 3, 4, 5]`.  This can cause indexes to either identify with the wrong columns or with no columns at all.   This PR includes a test case that breaks currently and a fix to correct it.