### PR TITLE
fix: no triggers on psql 11

### DIFF
--- a/module-files/sql/11/trigger.sql
+++ b/module-files/sql/11/trigger.sql
@@ -1,0 +1,42 @@
+SELECT
+  t.oid                                                                                     AS "oid",
+  c.relnamespace                                                                            AS "schemaOid",
+  tgrelid                                                                                   AS "entityOid",
+  tgname                                                                                    AS "name",
+  tgfoid                                                                                    AS "functionOid",
+
+  CASE t.tgtype::integer & 1 WHEN 1 THEN 'row' ELSE 'statement' END                         AS "orientation",
+
+  CASE t.tgtype::integer & 66
+    WHEN 2 THEN 'before'
+    WHEN 64 THEN 'insteadOf'
+    ELSE 'after'
+  END                                                                                       AS "timing",
+
+  regexp_split_to_array(LTRIM(
+    (CASE WHEN (tgtype::int::bit(7) & b'0000100')::int = 0 THEN '' ELSE ' insert' END) ||
+    (CASE WHEN (tgtype::int::bit(7) & b'0001000')::int = 0 THEN '' ELSE ' delete' END) ||
+    (CASE WHEN (tgtype::int::bit(7) & b'0010000')::int = 0 THEN '' ELSE ' update' END) ||
+    (CASE WHEN (tgtype::int::bit(7) & b'0100000')::int = 0 THEN '' ELSE ' truncate' END)
+  ), ' ')                                                                                   AS "events", -- Array, Ex:  {insert,delete,update}
+
+  (regexp_matches(pg_get_triggerdef(t.oid), '.{35,} WHEN \((.+)\) EXECUTE PROCEDURE'))[1]      AS "condition",
+
+  CASE tgenabled
+    WHEN 'O' THEN 'origin'
+    WHEN 'D' THEN 'disabled'
+    WHEN 'R' THEN 'replica'
+    WHEN 'A' THEN 'always'
+  END                                                                                       AS "isEnabled",
+
+  tgdeferrable                                                                              AS "isDeferrable",
+  tginitdeferred                                                                            AS "isInitiallyDeferred"
+
+FROM pg_trigger t -- https://www.postgresql.org/docs/12/catalog-pg-trigger.html
+INNER JOIN pg_class c ON c.oid = t.tgrelid
+WHERE
+  c.relnamespace = ANY ($1)
+  AND NOT tgisinternal -- Exclude internally generated  triggers.
+ORDER BY
+  c.relnamespace,
+  LOWER(tgname)


### PR DESCRIPTION
On PostgreSQL 11.5 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 8.1.0 (clang-802.0.42), 64-bit using pg-structure 7.2.6, trying to fetch triggers, returns an empty array.

It's good that test/trigger.test.ts fails!

The reason seems to be that pg_get_triggerdef on 11.4 returns N \((.+)\) EXECUTE PROCEDURE instead of N \((.+)\) EXECUTE FUNCTION

Fixes #61