### PR TITLE
fix(main): escape underscore to avoid over-ignoring schemas

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,8 +82,8 @@ async function getSchemas(
   const where: string[] = ["NOT pg_is_other_temp_schema(oid)", "nspname <> 'pg_toast'"];
   const whereInclude: string[] = [];
   const parameters: string[] = [];
-  const includedPatterns = include.concat(system && include.length > 0 ? ["information_schema", "pg_%"] : []);
-  const excludedPatterns = exclude.concat(system ? [] : ["information_schema", "pg_%"]);
+  const includedPatterns = include.concat(system && include.length > 0 ? ["information\\_schema", "pg\\_%"] : []);
+  const excludedPatterns = exclude.concat(system ? [] : ["information\\_schema", "pg\\_%"]);
 
   includedPatterns.forEach((pattern, i) => {
     whereInclude.push(`nspname LIKE $${i + 1}`); // nspname LIKE $1

--- a/src/pg-structure/constraint/foreign-key.ts
+++ b/src/pg-structure/constraint/foreign-key.ts
@@ -31,6 +31,9 @@ export default class ForeignKey extends Constraint {
     this.columns = IndexableArray.throwingFrom(args.columns, "name");
     this.table = args.table;
     this.mandatoryParent = this.columns.every((column) => column.notNull);
+    if (this.index === undefined) {
+      throw new Error(`Foreign key ${this.fullName} did not find an index, it might be in another schema`);
+    }
   }
 
   /**

--- a/src/pg-structure/constraint/foreign-key.ts
+++ b/src/pg-structure/constraint/foreign-key.ts
@@ -31,9 +31,8 @@ export default class ForeignKey extends Constraint {
     this.columns = IndexableArray.throwingFrom(args.columns, "name");
     this.table = args.table;
     this.mandatoryParent = this.columns.every((column) => column.notNull);
-    if (this.index === undefined) {
-      throw new Error(`Foreign key ${this.fullName} did not find an index, it might be in another schema`);
-    }
+    /* istanbul ignore if  */
+    if (this.index === undefined) throw new Error(`Foreign key ${this.fullName} did not find an index, it might be in another schema`);
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,7 +154,7 @@ export interface Options {
    * List of the schemas or a pattern similar to SQL's `LIKE` to select included schemas.
    *
    * @example
-   * const config = { includeSchemas: "public_%" }; // include all schemas starting with "public_"
+   * const config = { includeSchemas: "public\\_%" }; // include all schemas starting with "public_". `_` is an SQL wildcard character. You should escape it.
    *
    * @example
    * const config = { includeSchemas: ["public", "extra"] };


### PR DESCRIPTION
fix #92